### PR TITLE
Allow auth via EC2 instance profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@ Available variables are listed below, along with the default values:
 
 None
 
-## Example Playbook
+## Example Playbooks
+
+### Simple auth via keys
 
     - hosts: all
       roles:
@@ -34,6 +36,24 @@ None
           s3fs_fuse_bucket: ansible-s3fs-fuse
           s3fs_fuse_access_key_id: <your aws access key id>
           s3fs_fuse_secret_access_key: <your aws secret access key>
+
+### Use EC2 instance profile auth and custom options
+
+```
+- hosts: "tag_class_fuse"
+  roles:
+    - role: bastiaanvanassche.s3fs-fuse
+      s3fs_fuse_bucket: ansible-s3fs-fuse
+      s3fs_fuse_mount_point: "/media/fuseS3"
+      s3fs_fuse_cache_folder: "/tmp/fuseS3cache"
+      s3fs_fuse_mount_point_permissions: "0777"
+      s3fs_fuse_option_flags:
+        - "iam_role='iam_role_name'" # Role with sufficient access to the bucket
+        - "endpoint='eu-west-1'"
+        - "allow_other"
+        - "nonempty"
+
+```
 
 ## License
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -34,6 +34,7 @@
     owner="root"
     group="root"
     mode=0640
+  when: s3fs_fuse_access_key_id != ""
 
 - name: run chmod {{ s3fs_fuse_mount_point_permissions }} on mount folder {{ s3fs_fuse_mount_point }}
   file: path={{ s3fs_fuse_mount_point }} state=directory mode={{ s3fs_fuse_mount_point_permissions }}


### PR DESCRIPTION
Do not err if aws key/secret are not provided as the user might want to use
EC2 isntance profiles instead. Add an example of how it can be done to the
README.