### PR TITLE
Use fstab to mount the drive

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,18 +41,21 @@ None
 
 ```
 - hosts: "tag_class_fuse"
+  vars:
+    cache_dir: /tmp/fuseS3cache
   roles:
     - role: bastiaanvanassche.s3fs-fuse
       s3fs_fuse_bucket: ansible-s3fs-fuse
       s3fs_fuse_mount_point: "/media/fuseS3"
-      s3fs_fuse_cache_folder: "/tmp/fuseS3cache"
+      s3fs_fuse_cache_folder: "{{ cache_dir }}"
       s3fs_fuse_mount_point_permissions: "0777"
       s3fs_fuse_option_flags:
-        - "iam_role='iam_role_name'" # Role with sufficient access to the bucket
-        - "endpoint='eu-west-1'"
         - "allow_other"
         - "nonempty"
-
+        - "iam_role=iam_role_name" # Role with sufficient access to the bucket
+        - "endpoint=eu-west-1"
+        - "use_cache={{ cache_dir }}"
+        - "url=http://s3.amazonaws.com"
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -3,6 +3,11 @@
 
 Ansible role for mounting an AWS S3 bucket via FUSE. The role installs and configures [s3fs-fuse](https://github.com/s3fs-fuse/s3fs-fuse) on RedHat/CentOS or Debian/Ubuntu Linux.
 
+## Differences from the original bastiaanvanassche's repo
+
+  - More prominent way of using iam roles instead of key/secret for authentication
+  - Usage of fstab to persist mounted drives between restarts
+
 ## Requirements
 
 An AWS account and an existing S3 bucket. Tested on Ubuntu 12.04, 14.04, 16.04 and CentOS 7.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -46,20 +46,10 @@
   command: mount
   register: mount_list
 
-- name: mount folder {{ s3fs_fuse_mount_point }} to s3 bucket {{ s3fs_fuse_bucket }} using s3fs
-  command: >
-    s3fs
-    -o use_cache={{ s3fs_fuse_cache_folder }}
-    -o url={{ s3fs_fuse_url }}
-    {% for option in s3fs_fuse_option_flags %}
-    -o {{ option }}
-    {% endfor %}
-    {{ s3fs_fuse_bucket }} {{ s3fs_fuse_mount_point }}
-  register: command_result
-  tags:
-    - production
-# make sure this task is idempotent: ignore the 'already mounted' error thrown by s3fs.
-# https://groups.google.com/forum/#!topic/ansible-project/cIaQTmY3ZLE
-  failed_when: >
-    'according to mtab, s3fs is already mounted' not in command_result.stderr and command_result.rc == 1
-  when: s3fs_fuse_mount_point not in mount_list.stdout
+- name: Mount S3Fuse drive via fstab
+  mount:
+    path: "{{ s3fs_fuse_mount_point }}"
+    src: "s3fs#{{ s3fs_fuse_bucket }}"
+    fstype: fuse
+    opts: "{% for option in s3fs_fuse_option_flags %}{{ option }},{% endfor %}"
+    state: mounted


### PR DESCRIPTION
Mounting via command line utility s3fs does not add an fstab record, so the
mounted drive does not persist between reboots. Use fstab to mount the fuse
drive instead.